### PR TITLE
feat: add Facebook Pixel tracking script to layout component

### DIFF
--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -75,7 +75,33 @@ export default function RootLayout({ children }) {
         gtag('config', 'G-FJG9TZMHWM');
       `,
           }}
-        />
+  />
+  <script
+    dangerouslySetInnerHTML={{
+      __html: `
+  !function(f,b,e,v,n,t,s)
+  {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+  n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+  if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+  n.queue=[];t=b.createElement(e);t.async=!0;
+  t.src=v;s=b.getElementsByTagName(e)[0];
+  s.parentNode.insertBefore(t,s)}(window, document,'script',
+  'https://connect.facebook.net/en_US/fbevents.js');
+  fbq('init', '1752010645500910');
+  fbq('track', 'PageView');
+`,
+    }}
+  />
+  <noscript>
+    <img
+      height="1"
+      width="1"
+      style={{ display: "none" }}
+      src="https://www.facebook.com/tr?id=1752010645500910&ev=PageView&noscript=1"
+      alt=""
+    />
+  </noscript>
+
       </head>
       <body>
         <ThemeInit />


### PR DESCRIPTION
This pull request adds Facebook Pixel tracking to the application's root layout. The changes ensure that both JavaScript-enabled and non-JavaScript users are tracked for page views.

**Tracking Integration:**

* Added Facebook Pixel tracking script using `dangerouslySetInnerHTML` to the `RootLayout` component in `src/app/layout.jsx`, which initializes and tracks page views.
* Included a `<noscript>` fallback with a tracking image for users who have JavaScript disabled, ensuring comprehensive tracking coverage.