### PR TITLE
feat: enhance phone number validation in EcatalogForm component

### DIFF
--- a/src/app/download/EcatalogForm.jsx
+++ b/src/app/download/EcatalogForm.jsx
@@ -132,15 +132,32 @@ export default function EcatalogForm({ catalogTitle, onCancel, onSuccess }) {
           <Label htmlFor="ecatalog-phone">
             No. Telp (Whatsapp) <span className="text-red-500">*</span>
           </Label>
+
           <TextInput
             id="ecatalog-phone"
             name="phone"
             type="tel"
             value={formData.phone}
-            onChange={handleChange}
+            onChange={(e) => {
+              const value = e.target.value.replace(/\D/g, ""); // hanya angka
+              if (value.length <= 13) {
+                setFormData({ ...formData, phone: value });
+              }
+            }}
+            inputMode="numeric"
+            pattern="[0-9]{10,13}"
+            minLength={10}
+            maxLength={13}
             required
             disabled={isSubmitting}
           />
+
+          {formData.phone.length > 0 &&
+            (formData.phone.length < 10 || formData.phone.length > 13) && (
+              <p className="text-sm text-red-500 mt-1">
+                Nomor harus 10–13 digit dan hanya berisi angka.
+              </p>
+            )}
         </div>
 
         <div className="flex flex-col w-full sm:col-span-2">


### PR DESCRIPTION
This pull request introduces improved validation for the phone number input in the `EcatalogForm` component. The main focus is on ensuring that users enter only numeric values and that the phone number length falls within the required range.

Phone number validation improvements:

* The `onChange` handler for the `phone` field now strips non-numeric characters and restricts input to a maximum of 13 digits.
* Added HTML attributes (`inputMode`, `pattern`, `minLength`, `maxLength`) to guide numeric input and enforce length constraints.
* Displayed a validation message if the phone number is not between 10 and 13 digits, providing immediate feedback to the user.